### PR TITLE
build: Add publishing support

### DIFF
--- a/.github/workflows/glpi-agentmonitor-ci.yml
+++ b/.github/workflows/glpi-agentmonitor-ci.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   windows-compile:
     runs-on: windows-latest
-    
+
     strategy:
       matrix:
         arch: [ x64, x86 ]
-    
+
     steps:
     - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1.12.1
@@ -23,6 +23,10 @@ jobs:
     - name: Compile and link
       run: |
         msbuild GLPI-AgentMonitor.vcxproj -p:Configuration=Release -p:Platform=${{ matrix.arch }} -p:OutDir=Release\ -p:IntermediateOutputPath=Release\ -v:detailed -fl -flp:logfile=Release\msbuild.log
+    - name: Rename built binary to include ${{ matrix.arch }}
+      run: |
+        mv -f "Release\\GLPI-AgentMonitor.exe" "Release\\GLPI-AgentMonitor-${{ matrix.arch }}.exe"
+      shell: bash
     - name: Upload built artifact
       uses: actions/upload-artifact@v3
       with:
@@ -36,3 +40,27 @@ jobs:
         path: |
           Release\msbuild.log
           Release\*.tlog
+
+  release:
+
+    runs-on: ubuntu-latest
+
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: [ windows-compile ]
+
+    steps:
+    - name: Download x64 Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: GLPI-AgentMonitor-Build-x64
+    - name: Download x86 Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: GLPI-AgentMonitor-Build-x86
+    - name: Publish release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: GLPI Agent Monitor v${{ github.ref_name }}
+        fail_on_unmatched_files: true
+        files: |
+          GLPI-AgentMonitor-*.exe

--- a/.github/workflows/glpi-agentmonitor-ci.yml
+++ b/.github/workflows/glpi-agentmonitor-ci.yml
@@ -40,6 +40,55 @@ jobs:
         path: |
           Release\msbuild.log
           Release\*.tlog
+    - name: VirusTotal Scan submission
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: crazy-max/ghaction-virustotal@v3
+      with:
+        vt_api_key: ${{ secrets.VT_API_KEY }}
+        files: |
+          Release\\GLPI-AgentMonitor-${{ matrix.arch }}.exe
+    - name: VirusTotal Analysis report check
+      if: startsWith(github.ref, 'refs/tags/') && env.VT_API_KEY
+      run: |
+        let TRY=20
+        while curl -s --request GET --url https://www.virustotal.com/api/v3/files/$SHA256 --header "x-apikey: $VT_API_KEY" >vt.json
+        do
+            ERRCODE=$(jq .error.code vt.json 2>&1)
+            if [ "$ERRCODE" == "null" ]; then
+                if [ "$(jq .data.attributes.last_analysis_results.VBA32 vt.json)" != "null" ]; then
+                    echo "$(date): Current analysis stats:"
+                    jq .data.attributes.last_analysis_stats vt.json
+                    MALICIOUS="$(jq .data.attributes.last_analysis_stats.malicious vt.json)"
+                    SUSPICIOUS="$(jq .data.attributes.last_analysis_stats.suspicious vt.json)"
+                    if [ -n "$MALICIOUS" -a "$MALICIOUS" != "null" -a "$MALICIOUS" -gt 0 ]; then
+                      echo "::warning title=Malicious analysis reporting for GLPI-AgentMonitor-${{ matrix.arch }}.exe::See https://www.virustotal.com/gui/file/$SHA256"
+                    fi
+                    if [ -n "$SUSPICIOUS" -a "$SUSPICIOUS" != "null" -a "$SUSPICIOUS" -gt 0 ]; then
+                      echo "::warning title=Suspicious analysis reporting for GLPI-AgentMonitor-${{ matrix.arch }}.exe::See https://www.virustotal.com/gui/file/$SHA256"
+                    fi
+                    break
+                else
+                    echo "$(date): Analysis is running"
+                fi
+            else
+                echo "$(date): $ERRCODE"
+                if [ "$TRY" -lt 15 -a "$ERRCODE" != '"NotFoundError"' ]; then
+                    echo "$(date): Failing to access VT reporting"
+                    break
+                fi
+            fi
+            rm -f vt.json
+            if (( --TRY < 0 )); then
+                echo "$(date): Nothing to report"
+                break
+            fi
+            sleep 15
+        done
+        exit 0
+      shell: bash
+      env:
+        VT_API_KEY: ${{ secrets.VT_API_KEY }}
+        SHA256: ${{ steps.signing.outputs.sha256 }}
 
   release:
 
@@ -57,10 +106,32 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: GLPI-AgentMonitor-Build-x86
+    - name: Get sha256 sums
+      id: sha256
+      run: |
+        read X64 XXX <<< $( sha256sum GLPI-AgentMonitor-x64.exe )
+        read X86 XXX <<< $( sha256sum GLPI-AgentMonitor-x86.exe )
+        echo "GLPI-AgentMonitor-x64.exe SHA256: $X64"
+        echo "GLPI-AgentMonitor-x86.exe SHA256: $X86"
+        echo "x64=$X64" >>$GITHUB_OUTPUT
+        echo "x86=$X86" >>$GITHUB_OUTPUT
+      shell: bash
     - name: Publish release
       uses: softprops/action-gh-release@v1
       with:
+        draft: ${{ contains(github.ref_name, 'test') }}
+        prerelease: ${{ contains(github.ref_name, 'beta') }}
         name: GLPI Agent Monitor v${{ github.ref_name }}
+        body: |
+          ## For 64 bits windows OS, use:
+          [GLPI-AgentMonitor-x64.exe](https://github.com/glpi-project/glpi-agentmonitor/releases/download/${{ github.ref_name }}/GLPI-AgentMonitor-x64.exe)
+          
+          ## For 32 bits windows OS, use:
+          [GLPI-AgentMonitor-x86.exe](https://github.com/glpi-project/glpi-agentmonitor/releases/download/${{ github.ref_name }}/GLPI-AgentMonitor-x86.exe)
+          
+          ## VirusTotal reports
+          * [GLPI-AgentMonitor-x64.exe VirusTotal report](https://www.virustotal.com/gui/file/${{ steps.sha256.outputs.x64 }})
+          * [GLPI-AgentMonitor-x86.exe VirusTotal report](https://www.virustotal.com/gui/file/${{ steps.sha256.outputs.x86 }})
         fail_on_unmatched_files: true
         files: |
           GLPI-AgentMonitor-*.exe


### PR DESCRIPTION
Hi @redddcyclone 

this a PR to add a publishing step.

The purpose here is to rename the generated exe to include the `arch` in the name. Then a new job is added to download generated artifact and upload them into a one release. This job is triggered when a tag is set and published.

Maybe this job can be merged in the first job to publish each exe (without renaming) in its own release and by only setting the arch in the release name. Let me know what you think.

In place of renaming, maybe the project can be modified to still generate and exe with contains the arch in its name.

This PR is the same than the one I made for our fork. I only removed the code signing step as we use a really private process on which we can't provide more information than what you can read in our workflow ;-)

When the release is made, you may have to edit the release description so it looks prettier, like I did for our own: https://github.com/glpi-project/glpi-agentmonitor/releases/tag/1.0.0