### PR TITLE
Release 1.2.2 version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for GLPI Agent Monitor
 
+1.2.2
+
+* Build: Don't sign generated code with an expired code-signing certificate
 
 1.2.1
 

--- a/GLPI-AgentMonitor.rc2
+++ b/GLPI-AgentMonitor.rc2
@@ -16,8 +16,8 @@ VS_VERSION_INFO VERSIONINFO
  FILEVERSION VI_VERSIONDEF
  PRODUCTVERSION VI_VERSIONDEF
 #else
- FILEVERSION 1,2,1,0
- PRODUCTVERSION 1,2,1,0
+ FILEVERSION 1,2,2,0
+ PRODUCTVERSION 1,2,2,0
 #endif
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -37,7 +37,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "FileVersion", VI_VERSIONSTRING
 #else
-            VALUE "FileVersion", "1.2.1.0"
+            VALUE "FileVersion", "1.2.2.0"
 #endif
 #ifdef VI_FILENAME
             VALUE "InternalName", VI_FILENAME
@@ -54,7 +54,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "ProductVersion", VI_VERSIONSTRING
 #else
-            VALUE "ProductVersion", "1.2.1.0"
+            VALUE "ProductVersion", "1.2.2.0"
 #endif
         END
     END

--- a/version.h
+++ b/version.h
@@ -1,5 +1,5 @@
 // File overridden during GH Actions workflow run
 #define VI_FILENAME         "GLPI-AgentMonitor.exe"
-#define VI_VERSIONDEF       1,2,1,0
-#define VI_VERSIONSTRING    "1.2.1.0"
+#define VI_VERSIONDEF       1,2,2,0
+#define VI_VERSIONSTRING    "1.2.2.0"
 #define VI_PRODUCTNAME      "GLPI Agent Monitor"


### PR DESCRIPTION
Hi @redddcyclone 

I released a new version without code-signing enabled. Indeed we're preparing a glpi-agent release for next week and we decided to overcome the code-signing problem we had by not signing anything. SSL providers takes too long time to provide the certificate. We decided we can't wait anymore and we don't want to sign with an expired certificate.