### PR TITLE
New 1.3.0 version

### DIFF
--- a/.github/workflows/glpi-agentmonitor-ci.yml
+++ b/.github/workflows/glpi-agentmonitor-ci.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Download x64 Artifact
       uses: actions/download-artifact@v4
       with:
-        name: GLPI-AgentMonitor-Build-*
+        pattern: GLPI-AgentMonitor-Build-*
         merge-multiple: true
     - name: Get sha256 sums
       id: sha256

--- a/.github/workflows/glpi-agentmonitor-ci.yml
+++ b/.github/workflows/glpi-agentmonitor-ci.yml
@@ -15,8 +15,8 @@ jobs:
         arch: [ x64, x86 ]
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: ilammy/msvc-dev-cmd@v1.12.1
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         arch: ${{ matrix.arch }}
     - name: Set version
@@ -50,14 +50,14 @@ jobs:
         mv -f "Release\\GLPI-AgentMonitor.exe" "Release\\GLPI-AgentMonitor-${{ matrix.arch }}.exe"
       shell: bash
     - name: Upload built artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: GLPI-AgentMonitor-Build-${{ matrix.arch }}
         path: |
           Release\*.exe
     - name: Upload build logs artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: GLPI-AgentMonitor-BuildLogs-${{ matrix.arch }}
@@ -67,7 +67,7 @@ jobs:
           version.h
     - name: VirusTotal Scan submission
       if: startsWith(github.ref, 'refs/tags/')
-      uses: crazy-max/ghaction-virustotal@v3
+      uses: crazy-max/ghaction-virustotal@v4
       with:
         vt_api_key: ${{ secrets.VT_API_KEY }}
         files: |
@@ -124,13 +124,10 @@ jobs:
 
     steps:
     - name: Download x64 Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: GLPI-AgentMonitor-Build-x64
-    - name: Download x86 Artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: GLPI-AgentMonitor-Build-x86
+        name: GLPI-AgentMonitor-Build-*
+        merge-multiple: true
     - name: Get sha256 sums
       id: sha256
       run: |
@@ -142,7 +139,7 @@ jobs:
         echo "x86=$X86" >>$GITHUB_OUTPUT
       shell: bash
     - name: Publish release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         draft: ${{ contains(github.ref_name, 'test') }}
         prerelease: ${{ contains(github.ref_name, 'beta') }}

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Revision history for GLPI Agent Monitor
 
-Future release
+1.3.0
 
 * Better error message handling
   The Monitor now displays the error message when displaying error codes.

--- a/GLPI-AgentMonitor.rc2
+++ b/GLPI-AgentMonitor.rc2
@@ -16,8 +16,8 @@ VS_VERSION_INFO VERSIONINFO
  FILEVERSION VI_VERSIONDEF
  PRODUCTVERSION VI_VERSIONDEF
 #else
- FILEVERSION 1,2,3,0
- PRODUCTVERSION 1,2,3,0
+ FILEVERSION 1,3,0,0
+ PRODUCTVERSION 1,3,0,0
 #endif
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -37,7 +37,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "FileVersion", VI_VERSIONSTRING
 #else
-            VALUE "FileVersion", "1.2.3.0"
+            VALUE "FileVersion", "1.3.0.0"
 #endif
 #ifdef VI_FILENAME
             VALUE "InternalName", VI_FILENAME
@@ -54,7 +54,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "ProductVersion", VI_VERSIONSTRING
 #else
-            VALUE "ProductVersion", "1.2.3.0"
+            VALUE "ProductVersion", "1.3.0.0"
 #endif
         END
     END

--- a/version.h
+++ b/version.h
@@ -1,5 +1,5 @@
 // File overridden during GH Actions workflow run
 #define VI_FILENAME         "GLPI-AgentMonitor.exe"
-#define VI_VERSIONDEF       1,2,3,0
-#define VI_VERSIONSTRING    "1.2.3.0"
+#define VI_VERSIONDEF       1,3,0,0
+#define VI_VERSIONSTRING    "1.3.0.0"
 #define VI_PRODUCTNAME      "GLPI Agent Monitor"


### PR DESCRIPTION
Hi @redddcyclone 

I think we can now release GLPI-AgentMonitor.

I'm proposing to use 1.3.0 as version. But tell me if you prefer to use 1.2.4 or even 2.0.

Included in this PR is also a GH Actions workflow update to use updated actions. This will only prevent to have some deprecated warning in the GH Actions run summary.