### PR TITLE
New 1.4.0 version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Revision history for GLPI Agent Monitor
 
-Future release
+1.4.0
 
 * Dutch translation added
   Thanks Jeffrey Jansma (@perplexityjeff)

--- a/GLPI-AgentMonitor.rc2
+++ b/GLPI-AgentMonitor.rc2
@@ -16,8 +16,8 @@ VS_VERSION_INFO VERSIONINFO
  FILEVERSION VI_VERSIONDEF
  PRODUCTVERSION VI_VERSIONDEF
 #else
- FILEVERSION 1,3,1,0
- PRODUCTVERSION 1,3,1,0
+ FILEVERSION 1,4,0,0
+ PRODUCTVERSION 1,4,0,0
 #endif
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
@@ -37,7 +37,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "FileVersion", VI_VERSIONSTRING
 #else
-            VALUE "FileVersion", "1.3.1.0"
+            VALUE "FileVersion", "1.4.0.0"
 #endif
 #ifdef VI_FILENAME
             VALUE "InternalName", VI_FILENAME
@@ -54,7 +54,7 @@ BEGIN
 #ifdef VI_VERSIONSTRING
             VALUE "ProductVersion", VI_VERSIONSTRING
 #else
-            VALUE "ProductVersion", "1.3.1.0"
+            VALUE "ProductVersion", "1.4.0.0"
 #endif
         END
     END

--- a/version.h
+++ b/version.h
@@ -1,5 +1,5 @@
 // File overridden during GH Actions workflow run
 #define VI_FILENAME         "GLPI-AgentMonitor.exe"
-#define VI_VERSIONDEF       1,3,1,0
-#define VI_VERSIONSTRING    "1.3.1.0"
+#define VI_VERSIONDEF       1,4,0,0
+#define VI_VERSIONSTRING    "1.4.0.0"
 #define VI_PRODUCTNAME      "GLPI Agent Monitor"


### PR DESCRIPTION
Hi @redddcyclone 

I'm planning to release glpi-agent on next tuesday so I decided to release Glpi-AgentMonitor today with 1.4.0 as version.

Here is the PR to include my updates.